### PR TITLE
Change from debian:stable to debian:bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable AS builder
+FROM debian:bullseye AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -16,7 +16,7 @@ RUN cd orthorectify && \
     cmake -DCMAKE_BUILD_TYPE=Release .. && \
     make -j$(nproc)
 
-FROM debian:stable AS runner
+FROM debian:bullseye AS runner
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgomp1 libgdal28 && apt-get clean


### PR DESCRIPTION
This fixes errors like the following when trying to build:

```
7.362 E: Unable to locate package libgdal28
------
Dockerfile:21
--------------------
  20 |
  21 | >>> RUN apt-get update && apt-get install -y --no-install-recommends \
  22 | >>>     libgomp1 libgdal28 && apt-get clean
  23 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update && apt-get install -y --no-install-recommends     libgomp1 libgdal28 && apt-get clean" did not complete successfully: exit code: 100
```